### PR TITLE
Small url change that allow everyone to access the messenger app from we...

### DIFF
--- a/Messenger/AppDelegate.mm
+++ b/Messenger/AppDelegate.mm
@@ -23,7 +23,7 @@
   auto webView = [[WebView alloc] initWithFrame:{{0,0},{100,100}} frameName:@"main" groupName:@"main"];
   self.window.contentView = webView;
   webView.policyDelegate = self;
-  auto req = [[NSURLRequest alloc] initWithURL:[NSURL URLWithString:@"https://www.messenger.com/"]];
+  auto req = [[NSURLRequest alloc] initWithURL:[NSURL URLWithString:@"https://www.messenger.com/new"]];
   [webView.mainFrame loadRequest:req];
   
   // Sparkle


### PR DESCRIPTION
...b

Details:

Some users (myself included) can only access the app on the url messenger.com/new. Without the "/new" they're redirected to the page where you can download the app for mobile platforms.
