### PR TITLE
Add keyboard shortcut for search

### DIFF
--- a/Messenger/AppDelegate.mm
+++ b/Messenger/AppDelegate.mm
@@ -114,6 +114,10 @@
   _titlebarView.layer.opacity = 0;
 }
 
+- (IBAction)find:(NSMenuItem *)sender {
+  [_webView.windowScriptObject evaluateWebScript:@"document.querySelector('input[type=text]').focus();"];
+}
+
 
 - (IBAction)checkForUpdates:(id)sender {
   [[SUUpdater sharedUpdater] checkForUpdates:self];

--- a/Messenger/Base.lproj/MainMenu.xib
+++ b/Messenger/Base.lproj/MainMenu.xib
@@ -117,7 +117,7 @@
                                     <items>
                                         <menuItem title="Find…" tag="1" keyEquivalent="f" id="Xz5-n4-O0W">
                                             <connections>
-                                                <action selector="performFindPanelAction:" target="-1" id="cD7-Qs-BN4"/>
+                                                <action selector="find:" target="Voe-Tx-rLC" id="Xy3-Mf-lzQ"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem title="Find and Replace…" tag="12" keyEquivalent="f" id="YEy-JH-Tfz">


### PR DESCRIPTION
The search field is the only text input, so we can just query for `input[type=text]` and focus the first result. (By adding an action to the "Find…" menu item, we get ⌘F for free.)
