### PR TITLE
Round profile picture images in desktop notifications.

### DIFF
--- a/Messenger.xcodeproj/project.pbxproj
+++ b/Messenger.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		07DB23D81AD9E22E00177F14 /* NSImage+RoundCorner.m in Sources */ = {isa = PBXBuildFile; fileRef = 07DB23D71AD9E22E00177F14 /* NSImage+RoundCorner.m */; };
 		22C40EB11AD5C5E100FE12C1 /* icon.icns in Resources */ = {isa = PBXBuildFile; fileRef = 22C40EB01AD5C5E100FE12C1 /* icon.icns */; };
 		3A713BA01AD65F6500870D2A /* MEmbeddedRes.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A713B9F1AD65F6500870D2A /* MEmbeddedRes.m */; };
 		3A9A9C461AD5B407008FABE9 /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3A9A9C451AD5B407008FABE9 /* AppDelegate.mm */; };
@@ -53,6 +54,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		07DB23D61AD9E22E00177F14 /* NSImage+RoundCorner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSImage+RoundCorner.h"; sourceTree = "<group>"; };
+		07DB23D71AD9E22E00177F14 /* NSImage+RoundCorner.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSImage+RoundCorner.m"; sourceTree = "<group>"; };
 		22C40EB01AD5C5E100FE12C1 /* icon.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = icon.icns; sourceTree = "<group>"; };
 		3A713B9E1AD65F6500870D2A /* MEmbeddedRes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MEmbeddedRes.h; sourceTree = "<group>"; };
 		3A713B9F1AD65F6500870D2A /* MEmbeddedRes.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MEmbeddedRes.m; sourceTree = "<group>"; };
@@ -100,6 +103,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		07DB23D91AD9E23100177F14 /* Categories */ = {
+			isa = PBXGroup;
+			children = (
+				07DB23D61AD9E22E00177F14 /* NSImage+RoundCorner.h */,
+				07DB23D71AD9E22E00177F14 /* NSImage+RoundCorner.m */,
+			);
+			name = Categories;
+			sourceTree = "<group>";
+		};
 		3A9A9C361AD5B407008FABE9 = {
 			isa = PBXGroup;
 			children = (
@@ -129,6 +141,7 @@
 				3A713B9E1AD65F6500870D2A /* MEmbeddedRes.h */,
 				3A713B9F1AD65F6500870D2A /* MEmbeddedRes.m */,
 				3A9A9C741AD5D838008FABE9 /* JSAPI */,
+				07DB23D91AD9E23100177F14 /* Categories */,
 				3A9A9C491AD5B407008FABE9 /* Images.xcassets */,
 				3A9A9C4B1AD5B407008FABE9 /* MainMenu.xib */,
 				22C40EB01AD5C5E100FE12C1 /* icon.icns */,
@@ -259,6 +272,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3A9A9C481AD5B407008FABE9 /* main.m in Sources */,
+				07DB23D81AD9E22E00177F14 /* NSImage+RoundCorner.m in Sources */,
 				3A9A9C841AD5EA13008FABE9 /* JSObjWrapper.m in Sources */,
 				3A9A9C781AD5D873008FABE9 /* JSClass.mm in Sources */,
 				3A9A9C461AD5B407008FABE9 /* AppDelegate.mm in Sources */,

--- a/Messenger/JSNotification.js.mm
+++ b/Messenger/JSNotification.js.mm
@@ -1,3 +1,4 @@
+#import "NSImage+RoundCorner.h"
 #import "jsapi.h"
 #import "JSClass.hh"
 #import "JSObjWrapper.h"
@@ -56,7 +57,8 @@ struct JSNotification : JSClass {
 
     if (iconURL != nullptr) {
       dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        notif.contentImage = [[NSImage alloc] initWithContentsOfURL:iconURL];
+          NSImage *contentImage = [[NSImage alloc] initWithContentsOfURL:iconURL];
+        notif.contentImage = [contentImage roundedImage];
         dispatch_async(dispatch_get_main_queue(), ^{
           [[NSUserNotificationCenter defaultUserNotificationCenter] scheduleNotification:notif];
         });

--- a/Messenger/NSImage+RoundCorner.h
+++ b/Messenger/NSImage+RoundCorner.h
@@ -1,0 +1,15 @@
+//
+//  NSImage+RoundCorner.h
+//  Round Corner Image
+//
+//  Created by Venj Chu on 11/08/20.
+//  Copyright 2011年 Home. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+/* C Prototypes */
+void addRoundedRectToPath(CGContextRef context, CGRect rect, float ovalWidth, float ovalHeight);
+
+@interface NSImage(RoundCorner)
+- (NSImage *)roundCornersImageCornerRadius:(NSInteger)radius;
+@end

--- a/Messenger/NSImage+RoundCorner.h
+++ b/Messenger/NSImage+RoundCorner.h
@@ -11,5 +11,5 @@
 void addRoundedRectToPath(CGContextRef context, CGRect rect, float ovalWidth, float ovalHeight);
 
 @interface NSImage(RoundCorner)
-- (NSImage *)roundCornersImageCornerRadius:(NSInteger)radius;
+- (NSImage *)roundedImage;
 @end

--- a/Messenger/NSImage+RoundCorner.m
+++ b/Messenger/NSImage+RoundCorner.m
@@ -1,0 +1,62 @@
+//
+//  NSImage+RoundCorner.m
+//  Round Corner Image
+//
+//  Created by Venj Chu on 11/08/20.
+//  Copyright 2011年 Home. All rights reserved.
+//
+
+#import "NSImage+RoundCorner.h"
+
+@implementation NSImage (RoundCorner)
+
+void addRoundedRectToPath(CGContextRef context, CGRect rect, float ovalWidth, float ovalHeight)
+{
+    float fw, fh;
+    if (ovalWidth == 0 || ovalHeight == 0) {
+        CGContextAddRect(context, rect);
+        return;
+    }
+    CGContextSaveGState(context);
+    CGContextTranslateCTM (context, CGRectGetMinX(rect), CGRectGetMinY(rect));
+    CGContextScaleCTM (context, ovalWidth, ovalHeight);
+    fw = CGRectGetWidth (rect) / ovalWidth;
+    fh = CGRectGetHeight (rect) / ovalHeight;
+    CGContextMoveToPoint(context, fw, fh/2);
+    CGContextAddArcToPoint(context, fw, fh, fw/2, fh, 1);
+    CGContextAddArcToPoint(context, 0, fh, 0, fh/2, 1);
+    CGContextAddArcToPoint(context, 0, 0, fw/2, 0, 1);
+    CGContextAddArcToPoint(context, fw, 0, fw, fh/2, 1);
+    CGContextClosePath(context);
+    CGContextRestoreGState(context);
+}
+
+- (NSImage *)roundCornersImageCornerRadius:(NSInteger)radius {
+    int w = (int) self.size.width;
+    int h = (int) self.size.height;
+    
+    CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+    CGContextRef context = CGBitmapContextCreate(NULL, w, h, 8, 4 * w, colorSpace, kCGImageAlphaPremultipliedFirst);
+    
+    CGContextBeginPath(context);
+    CGRect rect = CGRectMake(0, 0, w, h);
+    addRoundedRectToPath(context, rect, radius, radius);
+    CGContextClosePath(context);
+    CGContextClip(context);
+    
+    CGImageRef cgImage = [[NSBitmapImageRep imageRepWithData:[self TIFFRepresentation]] CGImage];
+    
+    CGContextDrawImage(context, CGRectMake(0, 0, w, h), cgImage);
+    
+    CGImageRef imageMasked = CGBitmapContextCreateImage(context);
+    CGContextRelease(context);
+    CGColorSpaceRelease(colorSpace);
+    
+    NSImage *tmpImage = [[NSImage alloc] initWithCGImage:imageMasked size:self.size];
+    NSData *imageData = [tmpImage TIFFRepresentation];
+    NSImage *image = [[NSImage alloc] initWithData:imageData];
+    [tmpImage release];
+    
+    return [image autorelease];
+}
+@end

--- a/Messenger/NSImage+RoundCorner.m
+++ b/Messenger/NSImage+RoundCorner.m
@@ -31,12 +31,13 @@ void addRoundedRectToPath(CGContextRef context, CGRect rect, float ovalWidth, fl
     CGContextRestoreGState(context);
 }
 
-- (NSImage *)roundCornersImageCornerRadius:(NSInteger)radius {
+- (NSImage *)roundedImage {
     int w = (int) self.size.width;
     int h = (int) self.size.height;
+    int radius = (int) self.size.width < self.size.height ? self.size.width/2 : self.size.height/2;
     
     CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
-    CGContextRef context = CGBitmapContextCreate(NULL, w, h, 8, 4 * w, colorSpace, kCGImageAlphaPremultipliedFirst);
+    CGContextRef context = CGBitmapContextCreate(NULL, w, h, 8, 4 * w, colorSpace, (CGBitmapInfo)kCGImageAlphaPremultipliedFirst);
     
     CGContextBeginPath(context);
     CGRect rect = CGRectMake(0, 0, w, h);
@@ -54,9 +55,6 @@ void addRoundedRectToPath(CGContextRef context, CGRect rect, float ovalWidth, fl
     
     NSImage *tmpImage = [[NSImage alloc] initWithCGImage:imageMasked size:self.size];
     NSData *imageData = [tmpImage TIFFRepresentation];
-    NSImage *image = [[NSImage alloc] initWithData:imageData];
-    [tmpImage release];
-    
-    return [image autorelease];
+    return [[NSImage alloc] initWithData:imageData];
 }
 @end


### PR DESCRIPTION
So it's more consistent with profile picture presentation pretty much everywhere else.

Like this!
![screen shot 2015-04-11 at 4 30 04 pm](https://cloud.githubusercontent.com/assets/1578586/7103684/67e91dc6-e068-11e4-806f-af7e2bbd18d2.png)

Image rounding code from [here](https://github.com/venj/Cocoa-blog-code/tree/master/Round%20Corner%20Image/Round%20Corner%20Image).
