### PR TITLE
Always trigger manual text events

### DIFF
--- a/website/app/main.js
+++ b/website/app/main.js
@@ -55,12 +55,12 @@ window.MacMessenger = {
 
     // This fixes an annoying "beep" sound
     document.body.onkeypress = function (e) {
-      var target = e.target.contentEditable && e.target.querySelector('[data-block]');
-      if (target && !e.metaKey) {
+      if (e.target.contentEditable && !e.metaKey) {
+        e.preventDefault();
+ 
         var textEvent = document.createEvent('TextEvent');
         textEvent.initTextEvent('textInput', true, true, null, String.fromCharCode(e.which));
-        target.dispatchEvent(textEvent);
-        return false;
+        e.target.dispatchEvent(textEvent);
       }
     };
 

--- a/website/app/main.js
+++ b/website/app/main.js
@@ -56,7 +56,7 @@ window.MacMessenger = {
     // This fixes an annoying "beep" sound
     document.body.onkeypress = function (e) {
       var target = e.target.contentEditable && e.target.querySelector('[data-block]');
-      if (target && window.getSelection().baseOffset === 0 && !e.metaKey) {
+      if (target && !e.metaKey) {
         var textEvent = document.createEvent('TextEvent');
         textEvent.initTextEvent('textInput', true, true, null, String.fromCharCode(e.which));
         target.dispatchEvent(textEvent);


### PR DESCRIPTION
This code was originally based on fixing the first character input beep, but since there appears to be no side effect of manually creating all input events this would fix #97. This other solution would be to extend the `window.getSelection()` check to be something like `(window.getSelection().baseOffset === 0 || window.getSelection().focusOffset === 0)` but it’s starting to look fragile.
