### PR TITLE
Ignores about:blank requests. Fixes #126.

### DIFF
--- a/Messenger/AppDelegate.mm
+++ b/Messenger/AppDelegate.mm
@@ -594,6 +594,9 @@ decisionListener:(id<WebPolicyDecisionListener>)listener
       ) )
   {
     [listener use];
+  } else if ([[url description] isCaseInsensitiveLike:@"about:blank"]) {
+    NSLog(@"Ignore about:blank request.");
+    [listener ignore];
   } else {
     [self openWorkspaceURL:url];
     [listener ignore];

--- a/Messenger/AppDelegate.mm
+++ b/Messenger/AppDelegate.mm
@@ -595,7 +595,7 @@ decisionListener:(id<WebPolicyDecisionListener>)listener
   {
     [listener use];
   } else if ([[url description] isCaseInsensitiveLike:@"about:blank"]) {
-    NSLog(@"Ignore about:blank request.");
+    // NSLog(@"Ignore about:blank request."); Seems like a dirty workaround and probably needs further investigation.
     [listener ignore];
   } else {
     [self openWorkspaceURL:url];


### PR DESCRIPTION
Simply ignores about:blank requests to prevent the annoying window popups.
