### PR TITLE
Disable vertical scroll elasticity on parent webview.

### DIFF
--- a/Messenger/AppDelegate.mm
+++ b/Messenger/AppDelegate.mm
@@ -528,6 +528,9 @@ static void __attribute__((constructor))_init() {
       "s.backgroundImage='url(%@)';",
       kErrorPNGDataURL]];
   }
+  // Disable vertical scroll elasticity on parent webview scrollview
+  NSScrollView *scrollView = webView.mainFrame.frameView.documentView.enclosingScrollView;
+  [scrollView setVerticalScrollElasticity:NSScrollElasticityNone];
 }
 
 -(void)webView:(WebView *)webView didFailProvisionalLoadWithError:(NSError *)error forFrame:(WebFrame *)frame {


### PR DESCRIPTION
If the user vertically scrolls on the top menu navigation bars, the entire webView window will move. This is because the navigation bars on the webView are not scrollable, and so it scrolls the parent scrollView instead. See picture below:

![messengerverticalscrollenabled](https://cloud.githubusercontent.com/assets/1584690/8038192/0f7d289a-0dd0-11e5-97ae-9da1b7f5b269.png)

Disabling the vertical scroll elasticity on the parent webView's scrollView addresses this issue and makes it look more like a native app, rather than a webView :)
