### PR TITLE
Disabled contextual menu in release builds

### DIFF
--- a/Messenger.xcodeproj/project.pbxproj
+++ b/Messenger.xcodeproj/project.pbxproj
@@ -340,10 +340,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
@@ -407,7 +404,7 @@
 		};
 		3A9A9C5E1AD5B407008FABE9 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3A9A9C701AD5CA29008FABE9 /* messenger-debug.xcconfig */;
+			baseConfigurationReference = 3A9A9C711AD5CA29008FABE9 /* messenger-release.xcconfig */;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/Messenger/AppDelegate.mm
+++ b/Messenger/AppDelegate.mm
@@ -424,6 +424,12 @@ NSString* ReadDeviceID() {
 
 #pragma mark - WebUIDelegate
 
+#if !DEBUG
+-(NSArray *)webView:(WebView *)webView contextMenuItemsForElement:(NSDictionary *)element
+   defaultMenuItems:(NSArray *)defaultMenuItems {
+  return nil;
+}
+#endif
 
 - (NSUInteger)webView:(WebView *)webView dragDestinationActionMaskForDraggingInfo:(id <NSDraggingInfo>)draggingInfo {
   // This method is called periodically as something is dragged over a WebView.


### PR DESCRIPTION
The contextual menu prevented (although it shouldn't have) JS right click events (like right click to delete message). Also, it's largely irrelevant unless you want to Inspect Element (`#if DEBUG`) and it has a more native feel this way.
