### PR TITLE
Context menu fix. Fixes #128.

### DIFF
--- a/Messenger/AppDelegate.mm
+++ b/Messenger/AppDelegate.mm
@@ -756,6 +756,18 @@ static void NetReachCallback(SCNetworkReachabilityRef target,
 }
 
 
+- (NSArray *)webView:(WebView *)sender
+contextMenuItemsForElement:(NSDictionary *)element
+    defaultMenuItems:(NSArray *)defaultMenuItems {
+  #if DEBUG
+    if (([NSEvent modifierFlags] & NSControlKeyMask) == NSControlKeyMask) {
+      return defaultMenuItems;
+    }
+  #endif // DEBUG
+  return nil;
+}
+
+
 #pragma mark - WebFrameLoadDelegate
 
 

--- a/Messenger/AppDelegate.mm
+++ b/Messenger/AppDelegate.mm
@@ -175,6 +175,7 @@ static void NetReachCallback(SCNetworkReachabilityRef target,
   webView.frameLoadDelegate = self;
   webView.UIDelegate = self;
   webView.preferences = wp;
+  webView.maintainsBackForwardList = NO;
   webView.continuousSpellCheckingEnabled = YES;
   #if USE_BLURRY_BACKGROUND
   webView.drawsBackground = NO;


### PR DESCRIPTION
In debug mode, you can hold control + click to bring up the “Inspect Element.” Otherwise, this menu interferes with the JavaScript contextmenu event.
