### PR TITLE
Fixes switching between conversations with ⌘1…9

### DIFF
--- a/website/app/main.js
+++ b/website/app/main.js
@@ -106,7 +106,7 @@
     },
 
     selectConversationAtIndex: function(index) {
-      document.querySelector('div[aria-label="Conversations"] li:nth-child(' + (index + 1) +') a').click();
+      document.querySelector('div[aria-label="Conversations"] li:nth-child(' + index +') a').click();
     },
 
     currentConversationItem: function() {

--- a/website/app/main.js
+++ b/website/app/main.js
@@ -106,7 +106,7 @@
     },
 
     selectConversationAtIndex: function(index) {
-      document.querySelector('li:nth-child('+index+') > [data-reactid]:first-child').click();
+      document.querySelector('div[aria-label="Conversations"] li:nth-child(' + (index + 1) +') a').click();
     },
 
     currentConversationItem: function() {


### PR DESCRIPTION
Hi, :wave: 

Apparently Facebook changed their HTML structure.  This commit updates the CSS selector that is used to click conversations.
