### PR TITLE
Fixes broken focus of the search bar

### DIFF
--- a/website/app/main.js
+++ b/website/app/main.js
@@ -98,7 +98,7 @@
     },
 
     focusSearchField: function() {
-      document.querySelector('input[placeholder~="Search"]').focus();
+      document.querySelector('input[aria-autocomplete="list"]').focus();
     },
 
     focusComposer: function() {


### PR DESCRIPTION
Instead of using the placeholder when targeting the search bar the
script now uses an non-localized property.
