### PR TITLE
Filter instead of disabling the context menu.

### DIFF
--- a/Messenger/AppDelegate.mm
+++ b/Messenger/AppDelegate.mm
@@ -786,12 +786,27 @@ static void NetReachCallback(SCNetworkReachabilityRef target,
 
 
 - (NSArray*)webView:(WebView*)sender contextMenuItemsForElement:(NSDictionary *)element defaultMenuItems:(NSArray *)defaultMenuItems {
-  #if DEBUG
-  if (NSEvent.modifierFlags & NSAlternateKeyMask) {
-    return defaultMenuItems;
+  #if DEBUG && 1
+    NSLog(@"element = %@, menu items = %@, tags = %@", element, defaultMenuItems, [defaultMenuItems valueForKey:@"tag"]);
+  #endif // DEBUG
+
+  NSMutableArray *menuItems = [NSMutableArray new];
+  for (NSMenuItem *menuItem in defaultMenuItems) {
+    if ([menuItem isSeparatorItem] && ![menuItems count]) {
+      continue;
+    }
+    switch ([menuItem tag]) {
+      case WebMenuItemTagReload:
+        continue;
+      case 2024: // Inspect Element
+        if (NSEvent.modifierFlags & NSAlternateKeyMask) {
+          break;
+        }
+        continue;
+    }
+    [menuItems addObject:menuItem];
   }
-  #endif
-  return nil;
+  return ([menuItems count]) ? menuItems : nil;
 }
 
 


### PR DESCRIPTION
Fixes the spellcheck & substitutions context menu items.
