### PR TITLE
Fix deprecated .getDOMNode() call

### DIFF
--- a/website/app/main.js
+++ b/website/app/main.js
@@ -2,6 +2,7 @@
 
   function findReactDOMNode(options, instances) {
     var React = require("React");
+    var ReactDOM = require("ReactDOM");
     var ReactMount = require("ReactMount");
     var ret = null;
 
@@ -15,7 +16,7 @@
 
       if (options.name) {
         if (element && element.type && element.type.displayName == options.name) {
-          return instance.getPublicInstance().getDOMNode();
+          return ReactDOM.findDOMNode(instance.getPublicInstance());
         }
       } else if (options.id) {
         if (instance._rootNodeID == options.id) {


### PR DESCRIPTION
`instance.getDOMNode()` no longer works. React says we're supposed to use `ReactDOM.findDOMNode(instance)` instead.

The console errors before, for reference:
<img width="844" alt="screen shot 2016-02-08 at 7 49 20 am" src="https://cloud.githubusercontent.com/assets/5315059/12890432/811941ae-ce38-11e5-891e-33445117deca.png">

cc @rsms 
