### PR TITLE
Added SUFeedURL to Info.plist which was preventing messenger from starting

### DIFF
--- a/Messenger/Info.plist
+++ b/Messenger/Info.plist
@@ -71,5 +71,7 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>FBMApplication</string>
+	<key>SUFeedURL</key>
+	<string>https://fbmacmessenger.rsms.me/changelog.xml</string>
 </dict>
 </plist>


### PR DESCRIPTION
Fixes #273 and possibly #261 and #262

It's interesting that this solves the issue because it looks like the [url is set in code](https://github.com/rsms/fb-mac-messenger/blob/master/Messenger/AppDelegate.mm#L287)
