### PR TITLE
Reenable preferences, active friends, etc

### DIFF
--- a/Messenger/AppDelegate.h
+++ b/Messenger/AppDelegate.h
@@ -19,6 +19,9 @@ int FBMOSX1010OrNewer();
 - (IBAction)selectNewerConversation:(id)sender;
 - (BOOL)canSelectOlderConversation;
 - (IBAction)selectOlderConversation:(id)sender;
+- (void)showActiveFriends;
+- (void)showInbox;
+- (void)showMessageRequests;
 
 - (void)windowDidBecomeKey:(NSWindow*)w;
 // [self evaluateJavaScript:@"try { (typeof MacMessenger != 'undefined') && MacMessenger.focusComposer(); } catch(_) {}"];

--- a/Messenger/AppDelegate.mm
+++ b/Messenger/AppDelegate.mm
@@ -498,6 +498,14 @@ static void NetReachCallback(SCNetworkReachabilityRef target,
   [self evaluateJavaScript:@"MacMessenger.showSettings()"];
 }
 
+- (IBAction)showActiveFriends:(id)sender {
+  [self evaluateJavaScript:@"MacMessenger.showActiveFriends()"];
+}
+
+- (IBAction)showInbox:(id)sender {
+  [self evaluateJavaScript:@"MacMessenger.showInbox()"];
+}
+
 
 - (IBAction)showAppHelp:(id)sender {
   [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:@"https://www.facebook.com/help/735006619902401"]];

--- a/Messenger/AppDelegate.mm
+++ b/Messenger/AppDelegate.mm
@@ -484,6 +484,16 @@ static void NetReachCallback(SCNetworkReachabilityRef target,
   }
 }
 
+- (void)showActiveFriends {
+  [self evaluateJavaScript:@"MacMessenger.showActiveFriends()"];
+}
+- (void) showInbox {
+  [self evaluateJavaScript:@"MacMessenger.showInbox()"];
+}
+- (void)showMessageRequests {
+  [self evaluateJavaScript:@"MacMessenger.showMessageRequests()"];
+}
+
 - (IBAction)composeNewMessage:(id)sender {
   [self evaluateJavaScript:@"MacMessenger.composeNewMessage()"];
 }
@@ -499,11 +509,11 @@ static void NetReachCallback(SCNetworkReachabilityRef target,
 }
 
 - (IBAction)showActiveFriends:(id)sender {
-  [self evaluateJavaScript:@"MacMessenger.showActiveFriends()"];
+  [self showActiveFriends];
 }
 
 - (IBAction)showInbox:(id)sender {
-  [self evaluateJavaScript:@"MacMessenger.showInbox()"];
+  [self showInbox];
 }
 
 
@@ -529,7 +539,7 @@ static void NetReachCallback(SCNetworkReachabilityRef target,
 
 
 - (IBAction)showMessageRequests:(id)sender {
-  [self evaluateJavaScript:@"MacMessenger.showMessageRequests()"];
+  [self showMessageRequests];
 }
 
 

--- a/Messenger/Base.lproj/MainMenu.xib
+++ b/Messenger/Base.lproj/MainMenu.xib
@@ -282,22 +282,22 @@
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <menu key="submenu" title="View" id="g4l-96-7Lq" userLabel="View">
                         <items>
-                            <menuItem title="Message Requests" id="8Xh-P6-fno">
-                                <modifierMask key="keyEquivalentModifierMask"/>
+                            <menuItem title="Inbox" keyEquivalent="1" id="VkS-48-Y7U" userLabel="Inbox">
+                                <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
                                 <connections>
-                                    <action selector="showMessageRequests:" target="Voe-Tx-rLC" id="irK-zd-aru"/>
+                                    <action selector="showInbox:" target="Voe-Tx-rLC" id="pym-rF-Xcg"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Active Friends" id="bfM-KS-13L" userLabel="Active Friends">
-                                <modifierMask key="keyEquivalentModifierMask"/>
+                            <menuItem title="Active Friends" keyEquivalent="2" id="bfM-KS-13L" userLabel="Active Friends">
+                                <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
                                 <connections>
                                     <action selector="showActiveFriends:" target="Voe-Tx-rLC" id="hGV-yV-tAz"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Inbox" id="VkS-48-Y7U" userLabel="Inbox">
-                                <modifierMask key="keyEquivalentModifierMask"/>
+                            <menuItem title="Message Requests" keyEquivalent="3" id="8Xh-P6-fno">
+                                <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
                                 <connections>
-                                    <action selector="showInbox:" target="Voe-Tx-rLC" id="pym-rF-Xcg"/>
+                                    <action selector="showMessageRequests:" target="Voe-Tx-rLC" id="irK-zd-aru"/>
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="a1P-YN-Nhb"/>

--- a/Messenger/Base.lproj/MainMenu.xib
+++ b/Messenger/Base.lproj/MainMenu.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10102" systemVersion="15D21" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10102"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -286,6 +286,18 @@
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="showMessageRequests:" target="Voe-Tx-rLC" id="irK-zd-aru"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Active Friends" id="bfM-KS-13L" userLabel="Active Friends">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="showActiveFriends:" target="Voe-Tx-rLC" id="hGV-yV-tAz"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Inbox" id="VkS-48-Y7U" userLabel="Inbox">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="showInbox:" target="Voe-Tx-rLC" id="pym-rF-Xcg"/>
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="a1P-YN-Nhb"/>

--- a/Messenger/FBMApplication.mm
+++ b/Messenger/FBMApplication.mm
@@ -8,29 +8,53 @@
   if (event.type == NSKeyDown && (event.modifierFlags & NSCommandKeyMask)) {
     auto chars = event.charactersIgnoringModifiers;
     if (chars.length == 1) {
-      switch ([chars characterAtIndex:0]) {
-        case u'1' ... u'9': {
-          [((AppDelegate*)self.delegate) setActiveConversationAtIndex:event.characters];
-          return;
+      if (event.modifierFlags & NSAlternateKeyMask) {
+        switch ([chars characterAtIndex:0]) {
+          case u'1': {
+            AppDelegate* delegate = (AppDelegate*)[self delegate];
+            [delegate showInbox];
+            break;
+          }
+          case u'2': {
+            AppDelegate* delegate = (AppDelegate*)[self delegate];
+            [delegate showActiveFriends];
+            break;
+          }
+          case u'3': {
+            AppDelegate* delegate = (AppDelegate*)[self delegate];
+            [delegate showMessageRequests];
+            NSLog(@"got here");
+            break;
+          }
+          default: {
+            break;
+          }
         }
-        case u']': {
-          AppDelegate* delegate = (AppDelegate*)[self delegate];
-          if ([delegate canSelectOlderConversation]) {
-            [delegate selectOlderConversation:self];
+      } else {
+        switch ([chars characterAtIndex:0]) {
+          case u'1' ... u'9': {
+            [((AppDelegate*)self.delegate) setActiveConversationAtIndex:event.characters];
             return;
           }
-          break;
-        }
-        case u'[': {
-          AppDelegate* delegate = (AppDelegate*)[self delegate];
-          if ([delegate canSelectNewerConversation]) {
-            [delegate selectNewerConversation:self];
-            return;
+          case u']': {
+            AppDelegate* delegate = (AppDelegate*)[self delegate];
+            if ([delegate canSelectOlderConversation]) {
+              [delegate selectOlderConversation:self];
+              return;
+            }
+            break;
           }
-          break;
-        }
-        default: {
-          break;
+          case u'[': {
+            AppDelegate* delegate = (AppDelegate*)[self delegate];
+            if ([delegate canSelectNewerConversation]) {
+              [delegate selectNewerConversation:self];
+              return;
+            }
+            break;
+          }
+          default: {
+            break;
+          }
         }
       }
     }

--- a/website/app/main.js
+++ b/website/app/main.js
@@ -158,16 +158,16 @@
 
   window.MacMessenger = {
     tryFindSettingsGear: function() {
-      this.masterViewHeader = findReactDOMNodePath([
-        'MessengerMasterView',
-        'MessengerMasterViewHeader'
-      ], null, /*returnCI=*/true);
+      var main = findReactDOMNode({name: "Messenger"});
+      if (main) this.masterViewHeader = main.querySelector("div[role='banner']");
+//       this.masterViewHeader = findReactDOMNode({}, { a: document.querySelector("div[role='banner']") });
+//       this.gearButton = null;
+//      this.masterViewHeader = findReactDOMNodePath([
+//        'Messenger', 'div'
+////        'k', 'k', 'm'
+//      ], null, /*returnCI=*/true);
       var updateGearButton = (function() {
-        this.gearButton = findReactDOMNodePath(
-          ['MessengerMasterView','MessengerMasterViewHeader','MessengerSettingsMenu'],
-          null,
-          /*returnCI=*/true
-        );
+        this.gearButton = this.masterViewHeader.firstElementChild;
         if (this.gearButton) {
           var ReactDOM = require("ReactDOM");
           this.gearButtonNode = ReactDOM.findDOMNode(this.gearButton);
@@ -503,20 +503,12 @@
         observer.observe(document.body, { childList: true });
       }
     }
-    styleComponent("MessengerMasterView", {
+    styleComponent("Messenger", {
       "(max-width: 640px)": function(el, matches) {
         // Allow sidebar to go smaller
-        el.parentNode.style.minWidth = matches ? null : "280px";
-      }
-    });
-    styleComponent("MessengerMasterViewHeader", {
-      "(max-width: 640px)": function(el, matches) {
-        // Make banner contain children correctly
-        el.style.display = matches ? "block" : null;
-        
-        // Move over New Conversation button
+        el.firstElementChild.style.minWidth = matches ? null : "280px";
         var newConversation = el.querySelector("a[href='/new']");
-        newConversation.style.marginRight = matches ? "-49px" : null;
+        newConversation.style.marginRight = matches ? "-109px" : null;
         newConversation.style.float = matches ? "right" : null;
         newConversation.style.position = matches ? "relative" : null;
         newConversation.style.zIndex = matches ? "300" : null;

--- a/website/app/main.js
+++ b/website/app/main.js
@@ -512,11 +512,6 @@
         newConversation.style.float = matches ? "right" : null;
         newConversation.style.position = matches ? "relative" : null;
         newConversation.style.zIndex = matches ? "300" : null;
-                   
-        var back = el.querySelector("div[role='banner'] > a[href='#']");
-        if (back) {
-          
-        }
       }
     });
     styleComponent("MessengerRecentContainer", {

--- a/website/app/main.js
+++ b/website/app/main.js
@@ -528,8 +528,12 @@
               child.style.backgroundColor = matches ? color : null;
               child.style.border = matches ? ("2px solid " + color) : null;
               child.style.borderRadius = matches ? "50%" : null;
-              child.style.marginTop = matches ? "-44px" : null;
-              child.style.marginRight = matches ? "-2px" : null;
+              child.style.marginTop = matches ? "-34px" : null;
+              if (child.tagName == "IMG") {
+                child.style.marginRight = matches ? "-1px" : null;
+              } else {
+                child.style.marginLeft = matches ? "-3px" : null;
+              }
             }
           );
         });

--- a/website/app/main.js
+++ b/website/app/main.js
@@ -235,6 +235,8 @@
     },
  
     showActiveFriends: function() {
+      require('MessengerActions').changeMasterView(require('MessengerView').MASTER.RECENT);
+      require('MessengerActions').changeFolder(require('MessagingTag').INBOX);
       require('MessengerActions').changeMasterView(require('MessengerView').MASTER.PEOPLE);
     },
 

--- a/website/app/main.js
+++ b/website/app/main.js
@@ -151,6 +151,10 @@
       eachFn(key, object[key]);
     }
   };
+ 
+  var last = function(array) {
+    return array[array.length-1];
+  };
 
   // Note:
   //   window.MacMessengerVersion will be defined to a string e.g. to "0.1.2"
@@ -163,7 +167,6 @@
       var updateGearButton = (function() {
         this.gearButtonNode = this.masterViewHeader.firstElementChild;
         if (this.gearButtonNode) {
-          this.gearButton = reactComponentFromDOM(this.gearButtonNode);
           this._gearButtonAnchor = this.gearButtonNode.querySelector('a');
           
 
@@ -189,19 +192,13 @@
       }).bind(this);
 
       if (this.masterViewHeader) {
-//        var cdu = this.masterViewHeader.componentDidUpdate;
-//        this.masterViewHeader.componentDidUpdate = function(prevProps) {
-//          if (cdu) {
-//            cdu.apply(this, Array.prototype.slice.call(arguments));
-//          }
-//          if (this.props.folder === 'inbox') {
-//            ShowMainWindowTitlebar();
-//          } else {
-//            HideMainWindowTitlebar();
-//          }
-//          setTimeout(updateGearButton, 0);
-//        };
-//        updateGearButton();
+        this.headerObserver = new MutationObserver(function() {
+            updateGearButton();
+        });
+        this.headerObserver.observe(this.masterViewHeader, {
+          childList: true
+        });
+        updateGearButton();
         return true;
       }
       return false;
@@ -214,11 +211,9 @@
     },
  
     showSettings: function() {
-      if (!document.querySelector("ul[role='menu']")) {
-        this._gearButtonAnchor.click();
-        this._gearButtonAnchor.click();
-      }
-      var menuItem = document.querySelector("ul[role='menu'] li:first-child a");
+      this._gearButtonAnchor.click();
+      this._gearButtonAnchor.click();
+      var menuItem = last(document.querySelectorAll("ul[role='menu']")).querySelector("li:first-child a");
       menuItem.click();
     },
  
@@ -233,11 +228,9 @@
     },
 
     logOut: function() {
-       if (!document.querySelector("ul[role='menu']")) {
-        this._gearButtonAnchor.click();
-        this._gearButtonAnchor.click();
-      }
-      var menuItem = document.querySelector("ul[role='menu'] li:last-child a");
+      this._gearButtonAnchor.click();
+      this._gearButtonAnchor.click();
+      var menuItem = last(document.querySelectorAll("ul[role='menu']")).querySelector("li:last-child a");
       menuItem.click();
     },
  


### PR DESCRIPTION
Addresses https://github.com/rsms/fb-mac-messenger/issues/308, which is the base cause for https://github.com/rsms/fb-mac-messenger/issues/313, https://github.com/rsms/fb-mac-messenger/issues/309, and https://github.com/rsms/fb-mac-messenger/issues/305 as well.

So, here is what's changed on Facebook's side:
1. The left-side header is no longer its own React component
2. The gear menu itself is no longer its own React component

This means we can't easily grab the settings gear any more and we can't rely on calling methods directly on it. So here's what I did:
- I grab the header and gear button as regular DOM elements rather than React components
- I use CSS to hide the gear and back buttons since we can't rely on proxying `componentDidMount` any more, given that we don't have a component
- Digging through the messenger.com source, it looks like they switch sidebar views with `require('MessengerActions').changeMasterView(require('MessengerView').MASTER.RECENT)` and similar calls, so I use that
- Logging out and opening preferences are slightly more complicated since they require passing a React component argument into methods to attach the modal window onto a view, which is a little sketchy to try to replicate. Since preferences and logout are the first and last menu items respectively, it seems _relatively_ safe to try to click on those through the menu DOM.
  - Interesting side note about that: there still are methods attached to the menu that we could try to call directly, but they have names like `component.$MessengerSettingsMenu1()` (where, weirdly, they count from 1 to 11 but skip 6 and 10), so I figured these are not the sorts of methods we should rely on
  - Also, when going to the active friends menu and then returning to the inbox, Messenger leaves the old menu `ul` hidden in the DOM. If you open the menu, it creates a new one. If you go back and forth, it keeps adding more menus. So, when doing a DOM query to find the preferences and logout buttons, I do a `querySelectorAll` and grab the last one in order to make sure I get the most recent menu that has actual event listeners on it.

I also took the opportunity to add active friends list and inbox links into the View menu.

Let me know if there's anything in here that feels too sketchy or needs to be cleaned up!
