### PR TITLE
Remove images paste logic

### DIFF
--- a/Messenger/AppDelegate.mm
+++ b/Messenger/AppDelegate.mm
@@ -410,49 +410,7 @@ static void NetReachCallback(SCNetworkReachabilityRef target,
 }
 
 - (IBAction)paste:(id)sender {
-  NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
-
-  // If we've got an image, let's paste it!
-  // Ain't nobody got time for dirty hax with React.
-  if ([pasteboard canReadObjectForClasses:@[[NSImage class]] options:nil]) {
-    NSImage *pastedImage = [[pasteboard readObjectsForClasses:@[[NSImage class]] options:nil] firstObject];
-
-    // Try to grab the URL to the image being pasted (if it's available) to just repurpose the already useable pasteboard.
-    NSURL *pastedFileURL = [[pasteboard readObjectsForClasses:@[[NSURL class]] options:nil] firstObject];
-
-    // If we haven't got a file URL (screenshot), we need to write it out first.
-    if (pastedFileURL == nil) {
-      // Convert the pasteboard image to a PNG.
-      NSRect proposedRect = NSMakeRect(0, 0, pastedImage.size.width, pastedImage.size.height);
-      CGImageRef pastedImageRef = [pastedImage CGImageForProposedRect:&proposedRect
-                                                              context:NULL
-                                                                hints:nil];
-      NSBitmapImageRep *bitmapImageRep = [[NSBitmapImageRep alloc] initWithCGImage:pastedImageRef];
-      NSData *PNGImageData = [bitmapImageRep representationUsingType:NSPNGFileType properties:@{}];
-
-      // Save it (temporarily with a new name).
-      NSString *uniqueFilename = [[NSUUID UUID].UUIDString stringByAppendingString:@".png"];
-      NSString *tmpPath = [NSTemporaryDirectory() stringByAppendingPathComponent:uniqueFilename];
-      [PNGImageData writeToFile:tmpPath atomically:YES];
-
-      pastedFileURL = [NSURL fileURLWithPath:tmpPath];
-
-      // Write our newly saved file to the pasteboard.
-      [pasteboard clearContents];
-      [pasteboard declareTypes:@[NSFilenamesPboardType] owner:self];
-      [pasteboard writeObjects:@[pastedFileURL]];
-    }
-
-    if (pastedFileURL != nil) {
-      // Fire off a completely falsified (and bs) drag+drop event. >:D
-      MMFakeDragInfo *info = [[MMFakeDragInfo alloc] initWithImage:pastedImage pasteboard:pasteboard];
-      [_webView draggingEntered:info];
-      [_webView draggingUpdated:info];
-      [_webView performDragOperation:info];
-    }
-  } else {
     [[NSApplication sharedApplication] sendAction:@selector(paste:) to:nil from:self];
-  }
 }
 
 - (void)showActiveFriends {


### PR DESCRIPTION
Right now, copying file in Finder and pasting it in Messenger doesn't paste the file as attachment(in case for example .zip or .doc file), neither as an image (in case of png/jpg), but it pastes that file osx system icon. Also, pasting file from such an app as Snappy doesn't work (Messenger just does nothing. I have checked code, and there was some problem with generating fake drag&drop by MMFakeDragInfo). I have tested possible scenarios, and have found that all current logic isn't necessary, as pasting works perfectly well without it. 
This bug occurred on macOS Sierra, as well as OSX El Capitan.

Tested solution on macOS Sierra, and all paste file types work well. Correct me if I didn't take into account some other paste-scenario and that pull request will break it.
