### PR TITLE
Fix conversation prev/next navigation

### DIFF
--- a/Messenger/Base.lproj/MainMenu.xib
+++ b/Messenger/Base.lproj/MainMenu.xib
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11129.15" systemVersion="15G31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11129.15"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -430,20 +430,12 @@
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="eu3-7i-yIM"/>
-                            <menuItem title="Select Newer Conversation" id="vLj-4s-moH">
-                                <string key="keyEquivalent" base64-UTF8="YES">
-CQ
-</string>
-                                <modifierMask key="keyEquivalentModifierMask" control="YES"/>
+                            <menuItem title="Select Newer Conversation" keyEquivalent="[" id="vLj-4s-moH">
                                 <connections>
                                     <action selector="selectNewerConversation:" target="Voe-Tx-rLC" id="Esh-Ee-m8X"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="Select Older Conversation" id="eYP-FJ-B1X">
-                                <string key="keyEquivalent" base64-UTF8="YES">
-CQ
-</string>
-                                <modifierMask key="keyEquivalentModifierMask" shift="YES" control="YES"/>
+                            <menuItem title="Select Older Conversation" keyEquivalent="]" id="eYP-FJ-B1X">
                                 <connections>
                                     <action selector="selectOlderConversation:" target="Voe-Tx-rLC" id="8VD-OJ-Aec"/>
                                 </connections>

--- a/website/app/main.js
+++ b/website/app/main.js
@@ -260,7 +260,7 @@
     },
 
     currentConversationItem: function() {
-      return document.querySelector('li[role="log"]');
+      return document.querySelector('div[aria-label="Conversations"] li[aria-relevant]');
     },
 
     canSelectNewerConversation: function () {
@@ -270,7 +270,7 @@
     selectNewerConversation: function () {
       var newer = this.currentConversationItem().previousElementSibling;
       if (newer) {
-        newer.querySelector('[data-reactid]:first-child').click();
+        newer.querySelector('a').click();
       }
     },
 
@@ -281,7 +281,7 @@
     selectOlderConversation: function () {
       var newer = this.currentConversationItem().nextElementSibling;
       if (newer) {
-        newer.querySelector('[data-reactid]:first-child').click();
+        newer.querySelector('a').click();
       }
     },
 


### PR DESCRIPTION
Seems like Facebook changed their code again, the ⌃[⇧]⇥ shortcuts now conflict with the search feature, and the JS selectors no longer work.

This fixes the JS selectors, and also changes the keyboard shortcuts to ⌘] and ⌘[.