### PR TITLE
Prevent switching to discrete GPU automatically

### DIFF
--- a/Messenger/AppDelegate.mm
+++ b/Messenger/AppDelegate.mm
@@ -119,7 +119,7 @@ static void NetReachCallback(SCNetworkReachabilityRef target,
   
   ENABLE(localStorageEnabled);
   ENABLE(databasesEnabled);
-  ENABLE(webGLEnabled);
+  DISABLE(webGLEnabled);
   
   // Unofficial/Private settings
   ENABLE(acceleratedCompositingEnabled);

--- a/Messenger/Info.plist
+++ b/Messenger/Info.plist
@@ -71,6 +71,8 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>FBMApplication</string>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
 	<key>SUFeedURL</key>
 	<string>https://fbmacmessenger.rsms.me/changelog.xml</string>
 </dict>


### PR DESCRIPTION
Enabling WebGL would force a switch to the discrete GPU on launch, which drains battery life. Since there's no need for WebGL in Messenger, it can be safely disabled.

The `NSSupportsAutomaticGraphicsSwitching` is also helpful for ensuring correct behaviour.