### PR TITLE
Fixes #346

### DIFF
--- a/Messenger/AppDelegate.mm
+++ b/Messenger/AppDelegate.mm
@@ -119,7 +119,7 @@ static void NetReachCallback(SCNetworkReachabilityRef target,
   
   ENABLE(localStorageEnabled);
   ENABLE(databasesEnabled);
-  ENABLE(webGLEnabled);
+  //ENABLE(webGLEnabled);
   
   // Unofficial/Private settings
   ENABLE(acceleratedCompositingEnabled);


### PR DESCRIPTION
Not enabling WebGL stops the application from requiring high performance GPU on Macs with dual GPUs