### PR TITLE
Change react DOM element name to MessengerReact

### DIFF
--- a/website/app/main.js
+++ b/website/app/main.js
@@ -162,7 +162,7 @@
 
   window.MacMessenger = {
     tryFindSettingsGear: function() {
-      var main = findReactDOMNode({name: "Messenger"});
+      var main = findReactDOMNode({name: "MessengerReact"});
       if (main) this.masterViewHeader = main.querySelector("div[role='banner']");
       var updateGearButton = (function() {
         this.gearButtonNode = this.masterViewHeader.firstElementChild;


### PR DESCRIPTION
Messanger change the name of the banner node to "MessengerReact" that was causing `window.MacMessenger.tryFindSettingsGear()` to fail and thus `Cmd`+`,` couldn't open the settings window.
 
Resolves issue #352