### PR TITLE
Fix current, next and previous element selection

### DIFF
--- a/website/app/main.js
+++ b/website/app/main.js
@@ -260,7 +260,7 @@
     },
 
     currentConversationItem: function() {
-      return document.querySelector('li[role="log"]');
+      return document.querySelector('li[aria-relevant="additions text"]');
     },
 
     canSelectNewerConversation: function () {
@@ -270,7 +270,7 @@
     selectNewerConversation: function () {
       var newer = this.currentConversationItem().previousElementSibling;
       if (newer) {
-        newer.querySelector('[data-reactid]:first-child').click();
+        newer.querySelector('a').click();
       }
     },
 
@@ -281,7 +281,7 @@
     selectOlderConversation: function () {
       var newer = this.currentConversationItem().nextElementSibling;
       if (newer) {
-        newer.querySelector('[data-reactid]:first-child').click();
+        newer.querySelector('a').click();
       }
     },
 


### PR DESCRIPTION
The detection of the currently active chat was broken and therefore the shortcuts (`cmd`+`[` and `cmd`+`]`) to select the previous or next chat didn't work.

I fixed the currently active chat detection by looking up the `arel` attribute instead of `react-id` and updated the actions which simulate clicks on the respective elements accordingly.